### PR TITLE
Add workaround for sunrise/sunset calculation scheduler issue

### DIFF
--- a/bubbler.py
+++ b/bubbler.py
@@ -105,10 +105,11 @@ def calcsun():
     longitude = -79.552073
     tz_muskoka = pytz.timezone('America/Toronto')
     sun = Sun(latitude, longitude)
+    now = datetime.now()
     global today_sr
-    today_sr = sun.get_sunrise_time().astimezone(tz_muskoka).strftime("%H:%M")
+    today_sr = sun.get_sunrise_time(now).astimezone(tz_muskoka).strftime("%H:%M")
     global today_ss
-    today_ss = sun.get_sunset_time().astimezone(tz_muskoka).strftime("%H:%M")
+    today_ss = sun.get_sunset_time(now).astimezone(tz_muskoka).strftime("%H:%M")
     logging.debug("Running calcsun")
     logging.debug("new sunrise time: %s", today_sr)
     logging.debug("new sunset time: %s", today_ss)

--- a/suncalc.py
+++ b/suncalc.py
@@ -11,11 +11,11 @@ def calcsun():
     longitude = -79.552073
     tz_muskoka = pytz.timezone('America/Toronto')
     sun = Sun(latitude, longitude)
-    global today_sr
-    today_sr = sun.get_sunrise_time().astimezone(tz_muskoka).strftime("%H:%M")
-    global today_ss
-    today_ss = sun.get_sunset_time().astimezone(tz_muskoka).strftime("%H:%M")
     now = datetime.now()
+    global today_sr
+    today_sr = sun.get_sunrise_time(now).astimezone(tz_muskoka).strftime("%H:%M")
+    global today_ss
+    today_ss = sun.get_sunset_time(now).astimezone(tz_muskoka).strftime("%H:%M")
     ct = now.strftime("%H:%M")
     cd = date.today()
     print("Running calcsun at ", cd, ct)


### PR DESCRIPTION
There seems to be an unexpected interaction between the suntime module and the scheduler module that causes a scheduled call to the `get_sunrise_time()` and `get_sunset_time()` functions to use a version of `datetime.now()` that is "locked" or "frozen" to when the scheduler started.

`get_sunrise_time()` and `get_sunset_time()` have a default parameter `at_date` which has a default value of `datetime.now()` which should be used if you don't provide your own value for the parameter.  It seems like for some reason when you call either function using the schedule module, the time returned by `datetime.now` in the default parameter is the time when the call was first scheduled, not the time when the call is actually being made.  I'm not sure exactly why this is.

For some reason if you make a call to `datetime.now()` outside of the sunrise/sunset functions and pass that as the `at_date` parameter manually, it works as expected.  I'm not sure why this is either, maybe there is an optimization in the schedule module that determines default parameters once during scheduling and caches them.

I found this out by instrumenting the suntime module, adding a print call that outputs the value in `at_date`.  I also changed the schedule to call the function once per second.  Here it is the output before the fix in this PR:

```
ZZZ RUNNING SUNRISE TIME AT  15:24:10
Running calcsun at  2024-04-02 15:24:10
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:10
Running calcsun at  2024-04-02 15:24:11
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:10
Running calcsun at  2024-04-02 15:24:12
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:10
Running calcsun at  2024-04-02 15:24:13
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:10
Running calcsun at  2024-04-02 15:24:14
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:10
Running calcsun at  2024-04-02 15:24:15
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:10
Running calcsun at  2024-04-02 15:24:16
new sunrise time: 06:55
new sunset time: 19:48
```

The ZZZ line is from the instrumented suntime module, notice how it doesn't change.  Here's the output after the changes in this PR:

```
ZZZ RUNNING SUNRISE TIME AT  15:24:56
Running calcsun at  2024-04-02 15:24:56
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:57
Running calcsun at  2024-04-02 15:24:57
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:58
Running calcsun at  2024-04-02 15:24:58
new sunrise time: 06:55
new sunset time: 19:48
ZZZ RUNNING SUNRISE TIME AT  15:24:59
Running calcsun at  2024-04-02 15:24:59
new sunrise time: 06:55
new sunset time: 19:48
```

Long story short, `get_sunrise_time()` and `get_sunset_time()` when called with default parameters using the schedule module will always return the sunrise/sunset time from the time where the schedule was started, not the time where they were actually called.  That's why you saw them returning the same value until you restarted the script, which fixed it (until the next day at least).